### PR TITLE
Fix nvidia runtime issue on Windows

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -4,7 +4,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    runtime: nvidia
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
Fixes #1 

Fixed the following error on Windows.

```
~/easy-lora$ docker compose run train gsdf/Counterfeit-V2.5 zunko
[+] Building 0.0s (0/0)
[+] Building 0.0s (0/0)
Error response from daemon: unknown or invalid runtime name: nvidia
```

Note: On the recent WSL 2 environment, it seems NVIDIA runtime is installed and enabled by default.
https://docs.nvidia.com/cuda/wsl-user-guide/index.html#nvidia-gpu-accelerated-computing-on-wsl-2